### PR TITLE
Fixing squid: S1157 Case insensitive string comparisons should be made without intermediate upper or lower casing-

### DIFF
--- a/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
@@ -116,7 +116,7 @@ public class HttpUtil {
 		conn.setConnectTimeout(10000);
 		/* 设置请求类型 */
 		conn.setRequestMethod(type);
-		if (type.toUpperCase().equals("POST")) {
+		if (type.equalsIgnoreCase("POST")) {
 			/* setRequestProperty */
 			conn.setRequestProperty("Connection", "Keep-Alive");
 			conn.setRequestProperty("Charset", "UTF-8");
@@ -230,13 +230,13 @@ public class HttpUtil {
 	private static String getContentType(String fileExt) {
 		String contentType = "text/html; charset=UTF-8";
 		if (fileExt != null && fileExt.length() > 0) {
-			if (".jpg".equals(fileExt.toLowerCase()))
+			if (".jpg".equalsIgnoreCase(fileExt))
 				contentType = "image/jpeg";
-			else if (".amr".equals(fileExt.toLowerCase()))
+			else if (".amr".equalsIgnoreCase(fileExt))
 				contentType = "application/octet-stream";
-			else if (".mp3".equals(fileExt.toLowerCase()))
+			else if (".mp3".equalsIgnoreCase(fileExt))
 				contentType = "audio/mp3";
-			else if (".mp4".equals(fileExt.toLowerCase()))
+			else if (".mp4".equalsIgnoreCase(fileExt))
 				contentType = "video/mp4";
 			else
 				contentType = "application/octet-stream";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1157 - “Case insensitive string comparisons should be made without intermediate upper or lower casing”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1157
 Please let me know if you have any questions.
Fevzi Ozgul
