### PR TITLE
Fixing squid: S1319  Declarations should use Java collection interfacaces

### DIFF
--- a/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
@@ -9,6 +9,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 public class HttpUtil {
@@ -32,7 +33,7 @@ public class HttpUtil {
 	 * @return 请求返回值
 	 */
 	public static String post(String requestUrl,
-			HashMap<String, String> fileMaps, HashMap<String, String> parameters) {
+			Map<String, String> fileMaps, Map<String, String> parameters) {
 		String result = null;
 		try {
 			/* 初始化连接 */


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1319 - “Declarations should use Java collection interfaces such as ""List"" rather than specific implementation classes such as ""LinkedList"" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1319
 Please let me know if you have any questions.
Fevzi Ozgul
