### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/mandy/wechatrobot/util/Constants.java
+++ b/src/main/java/com/mandy/wechatrobot/util/Constants.java
@@ -1,7 +1,7 @@
 package com.mandy.wechatrobot.util;
 
 /** 常量类 */
-public class Constants {
+public final class Constants {
 
 	/* GET或POST（必须大写，不可更改） */
 	public static final String GET = "GET";
@@ -56,5 +56,5 @@ public class Constants {
 
 	/** 图灵机器人接口地址 */
 	public final static String TURING_API_URL = "http://www.tuling123.com/openapi/api";
-
+	private Constants(){}
 }

--- a/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
@@ -11,7 +11,7 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Map.Entry;
 
-public class HttpUtil {
+public final class HttpUtil {
 
 	/** 上传文件时定义数据分隔符(可以随意更改) **/
 	private static String boundary = "thisIsBoundary";
@@ -19,7 +19,8 @@ public class HttpUtil {
 	private static String twoHyphens = "--";
 	/** 上传文件时结尾标识 **/
 	private static String end = "\r\n";
-
+	
+    private HttpUtil(){}
 	/**
 	 * 发起http post请求，支持添加文件参数
 	 * 

--- a/src/main/java/com/mandy/wechatrobot/util/MessageUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/MessageUtil.java
@@ -23,8 +23,9 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.io.xml.PrettyPrintWriter;
 import com.thoughtworks.xstream.io.xml.XppDriver;
 
-public class MessageUtil {
-
+public final class MessageUtil {
+	
+	private MessageUtil(){}
 	/** 扩展xstream，使其支持CDATA块 */
 	private static XStream xstream = new XStream(new XppDriver() {
 		public HierarchicalStreamWriter createWriter(Writer out) {

--- a/src/main/java/com/mandy/wechatrobot/util/PropertiesLoader.java
+++ b/src/main/java/com/mandy/wechatrobot/util/PropertiesLoader.java
@@ -9,11 +9,13 @@ import com.opensymphony.xwork2.util.logging.LoggerFactory;
 /**
  * 配置加载类
  */
-public class PropertiesLoader {
+public final class PropertiesLoader {
 
 	private static Logger logger = LoggerFactory.getLogger(PropertiesLoader.class);
 	private static Properties properties = null;
-
+	
+    private PropertiesLoader(){}
+    
 	private static Properties getInterfaceProperties() {
 		if (properties == null) {
 			properties = new Properties();

--- a/src/main/java/com/mandy/wechatrobot/util/WeChatUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/WeChatUtil.java
@@ -10,13 +10,14 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
 /** 微信相关工具类 */
-public class WeChatUtil {
+public final class WeChatUtil {
 
 	/** 微信接口访问标记 **/
 	private static String accessToken = null;
 	/** 缓存时间 **/
 	private static Long cacheTime = null;
-
+    
+	private WeChatUtil(){}
 	/**
 	 * 验证微信消息合法性
 	 */


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
