### PR TITLE
Fixing squid: S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
+++ b/src/main/java/com/mandy/wechatrobot/util/HttpUtil.java
@@ -207,7 +207,7 @@ public class HttpUtil {
 			throws Exception {
 		BufferedReader bufferedReader = new BufferedReader(
 				new InputStreamReader(inputStream, "UTF-8"));
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		String str = null;
 		while ((str = bufferedReader.readLine()) != null) {
 			buffer.append(str);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Fevzi Ozgul
